### PR TITLE
template_registry.py: fix the duplicate check

### DIFF
--- a/lib/template_registry.py
+++ b/lib/template_registry.py
@@ -194,7 +194,7 @@ class TemplateRegistry(object):
             raise SubmitException("Incorrect size of nonce. Expected 8 chars")
 
         # Check for duplicated submit
-        if not job.register_submit(extranonce1_bin, extranonce2, ntime, nonce):
+        if not job.register_submit(extranonce1_bin, extranonce2.lower(), ntime.lower(), nonce.lower()):
             log.info("Duplicate from %s, (%s %s %s %s)" % \
                     (worker_name, binascii.hexlify(extranonce1_bin), extranonce2, ntime, nonce))
             raise SubmitException("Duplicate share")


### PR DESCRIPTION
since the duplicate check does only append all the
values and compares them case sensitive it is possible
to submit shares with different case but the same value.

this commit fixed this possible exploit.