### PR TITLE
segwit support

### DIFF
--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -10,6 +10,8 @@ from twisted.web import client
 import stratum.logger
 log = stratum.logger.get_logger('bitcoin_rpc')
 
+gbt_known_rules = ["segwit"]
+
 class BitcoinRPC(object):
 
     def __init__(self, host, port, username, password):
@@ -51,7 +53,7 @@ class BitcoinRPC(object):
 
     @defer.inlineCallbacks
     def getblocktemplate(self):
-        resp = (yield self._call('getblocktemplate', []))
+        resp = (yield self._call('getblocktemplate', [{"rules": gbt_known_rules}]))
         defer.returnValue(json.loads(resp)['result'])
 
     @defer.inlineCallbacks

--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -56,9 +56,9 @@ class BitcoinRPC(object):
 
     @defer.inlineCallbacks
     def prevhash(self):
-        resp = (yield self._call('getwork', []))
+        resp = (yield self._call('getbestblockhash', []))
         try:
-            defer.returnValue(json.loads(resp)['result']['data'][8:72])
+            defer.returnValue(json.loads(resp)['result'])
         except Exception as e:
             log.exception("Cannot decode prevhash %s" % str(e))
             raise

--- a/lib/block_template.py
+++ b/lib/block_template.py
@@ -6,10 +6,22 @@ import util
 import merkletree
 import halfnode
 from coinbasetx import CoinbaseTransaction
+from Crypto.Hash import SHA256
 
 # Remove dependency to settings, coinbase extras should be
 # provided from coinbaser
 from stratum import settings
+
+witness_nonce = b'\0' * 0x20
+witness_magic = b'\xaa\x21\xa9\xed'
+
+class TxBlob(object):
+    def __init__(self):
+        self.data = ''
+    def serialize(self):
+       return self.data
+    def deserialize(self, data):
+       self.data = data
 
 class BlockTemplate(halfnode.CBlock):
     '''Template is used for generating new jobs for clients.
@@ -30,6 +42,7 @@ class BlockTemplate(halfnode.CBlock):
         self.timedelta = 0
         self.curtime = 0
         self.target = 0
+        self.witness = 0
         #self.coinbase_hex = None
         self.merkletree = None
 
@@ -43,12 +56,30 @@ class BlockTemplate(halfnode.CBlock):
     def fill_from_rpc(self, data):
         '''Convert getblocktemplate result into BlockTemplate instance'''
 
-        #txhashes = [None] + [ binascii.unhexlify(t['hash']) for t in data['transactions'] ]
-        txhashes = [None] + [ util.ser_uint256(int(t['hash'], 16)) for t in data['transactions'] ]
-        mt = merkletree.MerkleTree(txhashes)
+        commitment = None
+        txids = []
+        hashes = [None] + [ util.ser_uint256(int(t['hash'], 16)) for t in data['transactions'] ]
+        try:
+            txids = [None] + [ util.ser_uint256(int(t['txid'], 16)) for t in data['transactions'] ]
+            mt = merkletree.MerkleTree(txids)
+        except KeyError:
+            mt = merkletree.MerkleTree(hashes)
+
+        wmt = merkletree.MerkleTree(hashes).withFirst(binascii.unhexlify('0000000000000000000000000000000000000000000000000000000000000000'))
+        self.witness = SHA256.new(SHA256.new(wmt + witness_nonce).digest()).digest()
+        commitment = b'\x6a' + struct.pack(">b", len(self.witness) + len(witness_magic)) + witness_magic + self.witness
+        try:
+            default_witness = data['default_witness_commitment']
+            commitment_check = binascii.unhexlify(default_witness)
+            if(commitment != commitment_check):
+                print("calculated witness does not match supplied one! This block probably will not be accepted!")
+                commitment = commitment_check
+        except KeyError:
+            pass
+        self.witness = commitment[6:]
 
         coinbase = self.coinbase_transaction_class(self.timestamper, self.coinbaser, data['coinbasevalue'],
-                        data['coinbaseaux']['flags'], data['height'], settings.COINBASE_EXTRAS)
+                        data['coinbaseaux']['flags'], data['height'], commitment, settings.COINBASE_EXTRAS)
 
         self.height = data['height']
         self.nVersion = data['version']
@@ -60,8 +91,8 @@ class BlockTemplate(halfnode.CBlock):
         self.vtx = [ coinbase, ]
 
         for tx in data['transactions']:
-            t = halfnode.CTransaction()
-            t.deserialize(StringIO.StringIO(binascii.unhexlify(tx['data'])))
+            t = TxBlob()
+            t.deserialize(binascii.unhexlify(tx['data']))
             self.vtx.append(t)
 
         self.curtime = data['curtime']
@@ -138,3 +169,34 @@ class BlockTemplate(halfnode.CBlock):
         self.nNonce = nonce
         self.vtx[0].set_extranonce(extranonce1_bin + extranonce2_bin)
         self.sha256 = None # We changed block parameters, let's reset sha256 cache
+
+    def serialize(self):
+        r = []
+        r.append(struct.pack("<i", self.nVersion))
+        r.append(util.ser_uint256(self.hashPrevBlock))
+        r.append(util.ser_uint256(self.hashMerkleRoot))
+        r.append(struct.pack("<I", self.nTime))
+        r.append(struct.pack("<I", self.nBits))
+        r.append(struct.pack("<I", self.nNonce))
+        r.append(util.ser_vector(self.vtx))
+        return ''.join(r)
+
+    def is_valid(self):
+        self.calc_sha256()
+        target = util.uint256_from_compact(self.nBits)
+        if self.sha256 > self.target:
+            return False
+        hashes = []
+        hashes.append(b'\0' * 0x20)
+        for tx in self.vtx[1:]:
+            hashes.append(SHA256.new(SHA256.new(tx.serialize()).digest()).digest())
+        while len(hashes) > 1:
+            newhashes = []
+            for i in xrange(0, len(hashes), 2):
+                i2 = min(i+1, len(hashes)-1)
+                newhashes.append(SHA256.new(SHA256.new(hashes[i] + hashes[i2]).digest()).digest())
+            hashes = newhashes
+        calcwitness = SHA256.new(SHA256.new(hashes[0] + witness_nonce).digest()).digest()
+        if calcwitness != self.witness:
+            return False
+        return True

--- a/lib/block_updater.py
+++ b/lib/block_updater.py
@@ -44,7 +44,7 @@ class BlockUpdater(object):
             else:
                 current_prevhash = None
 
-            prevhash = util.reverse_hash((yield self.bitcoin_rpc.prevhash()))
+            prevhash = yield self.bitcoin_rpc.prevhash()
             if prevhash and prevhash != current_prevhash:
                 log.info("New block! Prevhash: %s" % prevhash)
                 update = True

--- a/lib/coinbasetx.py
+++ b/lib/coinbasetx.py
@@ -12,7 +12,7 @@ class CoinbaseTransaction(halfnode.CTransaction):
     extranonce_placeholder = struct.pack(extranonce_type, int('f000000ff111111f', 16))
     extranonce_size = struct.calcsize(extranonce_type)
 
-    def __init__(self, timestamper, coinbaser, value, flags, height, data):
+    def __init__(self, timestamper, coinbaser, value, flags, height, commitment, data):
         super(CoinbaseTransaction, self).__init__()
 
         #self.extranonce = 0
@@ -38,6 +38,11 @@ class CoinbaseTransaction(halfnode.CTransaction):
         self.vin.append(tx_in)
         self.vout.append(tx_out)
 
+        if(commitment):
+            txout_commitment = halfnode.CTxOut()
+            txout_commitment.nValue = 0
+            txout_commitment.scriptPubKey = commitment
+            self.vout.append(txout_commitment)
         # Two parts of serialized coinbase, just put part1 + extranonce + part2 to have final serialized tx
         self._serialized = super(CoinbaseTransaction, self).serialize().split(self.extranonce_placeholder)
 


### PR DESCRIPTION
Adds support for requesting segwit support in gbt calls, as well as the necessary commitment insertion.

Commitments will be inserted even before segwit activation, so it's possible to verify that the insertion works far in advance.

Compares the calculated commitment to the one provided by bitcoind, if present, as an extra sanity check.